### PR TITLE
Use a single profile

### DIFF
--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -2,33 +2,51 @@
 // This file can be renamed, and additional FSH files can be added.
 // SUSHI will look for definitions in any file using the .fsh ending.
 
-Instance: JohnDoe
-InstanceOf: Patient
-Description: "An example of a patient DAR extensions for most fields."
+Profile: CombinedEuropeanPatient
+Parent: Patient
+Id: combined-european-patient-profile
+Title: "Combined European Patient Profile."
+Description: "A profile enforcing all known European profiles for the Patient resource."
 // IPA
-* meta.profile[0] = "http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-patient"
+* ^extension[0].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-patient"
 // IPS
-* meta.profile[+] = "http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips"
-// Denmark
-* meta.profile[+] = "http://hl7.dk/fhir/core/StructureDefinition/dk-core-patient"
-// Norway
-* meta.profile[+] = "http://hl7.no/fhir/StructureDefinition/no-basis-Patient"
-// Sweden
-* meta.profile[+] = "http://hl7.se/fhir/ig/base/StructureDefinition/SEBasePatient"
-// Finland
-* meta.profile[+] = "https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient"
-// Switzerland
-* meta.profile[+] = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient" 
-// Belgium
-* meta.profile[+] = "https://www.ehealth.fgov.be/standards/fhir/core/StructureDefinition/be-patient" 
-// Estonia
-* meta.profile[+] = "https://fhir.ee/StructureDefinition/ee-patient" 
-// France
-* meta.profile[+] = "http://interopsante.org/fhir/StructureDefinition/FrPatient" 
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips"
+// BE
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "https://www.ehealth.fgov.be/standards/fhir/core/StructureDefinition/be-patient"
+// CH
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient"
+// DK
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://hl7.dk/fhir/core/StructureDefinition/dk-core-patient"
+// EE
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "https://fhir.ee/StructureDefinition/ee-patient"
+// FI
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient"
+// FR
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://interopsante.org/fhir/StructureDefinition/FrPatient"
+// NL
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"
+// NO
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://hl7.no/fhir/StructureDefinition/no-basis-Patient"
+// SE
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "http://hl7.se/fhir/ig/base/StructureDefinition/SEBasePatient"
 // UK
-* meta.profile[+] = "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" 
-// Netherlands
-* meta.profile[+] = "http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" 
+* ^extension[+].url = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile"
+* ^extension[=].valueCanonical = "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient"
+
+Instance: JohnDoe
+InstanceOf: CombinedEuropeanPatient
+Description: "An example of a patient DAR extensions for most fields."
 * name
   * given[0].extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
   * given[0].extension.valueCode = #unknown
@@ -47,32 +65,8 @@ Description: "An example of a patient DAR extensions for most fields."
 
 
 Instance: JaneDoe
-InstanceOf: Patient
+InstanceOf: CombinedEuropeanPatient
 Description: "An example of a patient almost no values."
-// IPA
-* meta.profile[0] = "http://hl7.org/fhir/uv/ipa/StructureDefinition/ipa-patient"
-// IPS
-* meta.profile[+] = "http://hl7.org/fhir/uv/ips/StructureDefinition/Patient-uv-ips"
-// Denmark
-* meta.profile[+] = "http://hl7.dk/fhir/core/StructureDefinition/dk-core-patient"
-// Norway
-* meta.profile[+] = "http://hl7.no/fhir/StructureDefinition/no-basis-Patient"
-// Sweden
-* meta.profile[+] = "http://hl7.se/fhir/ig/base/StructureDefinition/SEBasePatient"
-// Finland
-* meta.profile[+] = "https://hl7.fi/fhir/finnish-base-profiles/StructureDefinition/fi-base-patient"
-// Switzerland
-* meta.profile[+] = "http://fhir.ch/ig/ch-core/StructureDefinition/ch-core-patient" 
-// Belgium
-* meta.profile[+] = "https://www.ehealth.fgov.be/standards/fhir/core/StructureDefinition/be-patient" 
-// Estonia
-* meta.profile[+] = "https://fhir.ee/StructureDefinition/ee-patient" 
-// France
-* meta.profile[+] = "http://interopsante.org/fhir/StructureDefinition/FrPatient" 
-// UK
-* meta.profile[+] = "https://fhir.hl7.org.uk/StructureDefinition/UKCore-Patient" 
-// Netherlands
-* meta.profile[+] = "http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" 
 * name
   * given[0] = "Jane"
   * family = "Doe"

--- a/input/fsh/patient.fsh
+++ b/input/fsh/patient.fsh
@@ -53,8 +53,10 @@ Description: "An example of a patient DAR extensions for most fields."
   * family.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
   * family.extension.valueCode = #unknown
   * use = #anonymous
+/*
 * identifier.system.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
 * identifier.system.extension.valueCode = #unknown
+*/
 * identifier.value.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
 * identifier.value.extension.valueCode = #unknown
 * birthDate.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"


### PR DESCRIPTION
Rather than declaring each profile in the `.meta.profile` field of each example instance, create one profile that includes (and imposes) all known profiles, and make the examples conform to that single profile.
